### PR TITLE
feat(RSSI-560): adiciona o segmento Y52 para receber chave de nota fiscal da BRF

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         run: go mod download
 
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum
+        run: go install gotest.tools/gotestsum@latest
 
       - name: Run unit tests
         run: make unit-test

--- a/brf240/billing.go
+++ b/brf240/billing.go
@@ -88,6 +88,24 @@ type BillingSegmentA struct {
 	Occurrence            string          `translator:"part:230..239"`                              //Status da Partida/Código de ocorrência  231..240   X(010)
 }
 
+type BillingSegmentY52 struct {
+	BankCode              string `translator:"part:0..2"`                   //Código do Banco                         001..003   9(003)
+	BatchNumber           int    `translator:"part:3..6"`                   //Lote de Serviço                         004..007   9(004)
+	RegistryKind          int    `translator:"part:7..7;kind:3"`            //Tipo de Registro                        008..008   9(001)
+	BatchSequentialNumber int    `translator:"part:8..12"`                  //Número Seqüencial do Registro no Lote   009..013   9(005)
+	SegmentKind           string `translator:"part:13..13;segment:Y"`       //Código Segmento do Registro Detalhe     014..014   X(001)
+	ActionInstructionKind int    `translator:"part:15..16"`                 //Código da Instrução para Movimento      016..017   9(002)
+	OptionalRegistryId    string `translator:"part:17..18"`                 //Identificação Registro Opcional         018..019   9(002)
+	FiscalDocumentNumber1 string `translator:"part:19..33;clearZeroLeft"`   //Número da Nota Fiscal 1                 020..034   X(015)
+	FiscalDocumentValue1  string `translator:"part:34..48;clearZeroLeft"`   //Valor da Nota Fiscal 1                  035..049   9(015)
+	FiscalDocumentDate1   string `translator:"part:49..56"`                 //Data Emissão da Nota Fiscal 1           050..057   9(008)
+	FiscalDocumentKey1    string `translator:"part:57..100"`                //Chave de Acesso DANFE NF 1              058..101   9(044)
+	FiscalDocumentNumber2 string `translator:"part:101..115;clearZeroLeft"` //Número da Nota Fiscal 2                 102..116   X(015)
+	FiscalDocumentValue2  string `translator:"part:116..130;clearZeroLeft"` //Valor da Nota Fiscal 2                  117..131   9(015)
+	FiscalDocumentDate2   string `translator:"part:131..139"`               //Data Emissão da Nota Fiscal 2           132..140   9(009)
+	FiscalDocumentKey2    string `translator:"part:140..183"`               //Chave de Acesso DANFE NF 2              141..184   9(044)
+}
+
 type BillingBatchTrailer struct {
 	BankCode                string          `translator:"part:0..2"`               //Código do Banco                      001..003   9(003)
 	BatchNumber             int             `translator:"part:3..6"`               //Lote de Serviço                      004..007   9(004

--- a/brf240/billing_test.go
+++ b/brf240/billing_test.go
@@ -155,6 +155,32 @@ func TestBillingSegmentAReceiptParse(t *testing.T) {
 	assert.Equal(t, expected_segment_a, parsed)
 }
 
+func TestBillingBillingSegmentY52Parse(t *testing.T) {
+	file_segment_y52 := "2370001300001Y 00520000000000120510000000004431823009202341230900766315001035570200000120511001205197                                                                                                                                          "
+
+	expected_segment_y52 := brf240.BillingSegmentY52{
+		BankCode:              "237",
+		BatchNumber:           1,
+		RegistryKind:          3,
+		BatchSequentialNumber: 1,
+		SegmentKind:           "Y",
+		ActionInstructionKind: 0,
+		OptionalRegistryId:    "52",
+		FiscalDocumentNumber1: "12051",
+		FiscalDocumentValue1:  "443182",
+		FiscalDocumentDate1:   "30092023",
+		FiscalDocumentKey1:    "41230900766315001035570200000120511001205197",
+		FiscalDocumentNumber2: "",
+		FiscalDocumentValue2:  "",
+		FiscalDocumentDate2:   "",
+		FiscalDocumentKey2:    "",
+	}
+	parsed, err := brf240.Parse(file_segment_y52)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected_segment_y52, parsed)
+}
+
 func TestBillingBatchTrailerParse(t *testing.T) {
 	file_trailer := "35300015         035193000000040420170731000000000000000000                                                                                                                                                                                     "
 	expected_value_amount, _ := decimal.NewFromString("404201707.31")

--- a/brf240/translator.go
+++ b/brf240/translator.go
@@ -5,10 +5,11 @@ import (
 )
 
 const (
-	kindPosition        = 7
-	segmentPosition     = 13
-	instructionPosition = 15
-	instructionLength   = 2
+	kindPosition             = 7
+	segmentPosition          = 13
+	instructionPosition      = 15
+	optionalRegistryPosition = 17
+	instructionLength        = 2
 )
 
 var objectKind = map[string]interface{}{
@@ -32,6 +33,12 @@ var parseObjectFunc = func(line string) interface{} {
 
 	if segment == "A" && instruction == "12" {
 		return new(BillingSegmentAReceipt)
+	}
+
+	var optionalRegistry = line[optionalRegistryPosition : optionalRegistryPosition+instructionLength]
+
+	if segment == "Y" && optionalRegistry == "52" {
+		return new(BillingSegmentY52)
 	}
 
 	return new(BillingSegmentA)


### PR DESCRIPTION
**Escopo**

A BRF enviará as chaves de nota fiscal dos títulos como requisito do Bradesco para operar títulos.

**Implementação**

. adicionei um novo segmento BillingSegmentY52;
. adicionei ao parse a identificação para esse tipo de registro;
. adicionei teste.

**Como testar**

Esse arquivo é parte da solução, é possível apenas verificar se o parse é feito corretamente, ainda não está adiciona à mensagem de saída.
