### PR TITLE
[RSSI-862] Add precision to writer and add tests to brf240

### DIFF
--- a/brf240/billing_return.go
+++ b/brf240/billing_return.go
@@ -108,10 +108,10 @@ type BillingReturnSegmentA struct {
 	PaymentNumber         string          `translator:"part:108..129"`                    //Número da Nota Fiscal/Fatura            109..130   X(022)
 	IssueDate             time.Time       `translator:"part:130..137;timeParse:02012006"` //Data de emissão do documento            131..138   X(008)
 	DueDate               time.Time       `translator:"part:138..145;timeParse:02012006"` //Data do vencimento                      139..146   X(008)
-	PaymentValue          decimal.Decimal `translator:"part:146..166"`                    //Valor do título                         147..167   9(021)(2)
-	DiscountValue         decimal.Decimal `translator:"part:167..180"`                    //Valor do desconto                       168..181   9(012)(2)
-	FinancingValue        decimal.Decimal `translator:"part:181..194"`                    //Valor liquido                           182..195   9(012)(2)
-	DiscountRate          decimal.Decimal `translator:"part:195..200"`                    //Taxa de adiantamento                    196..201   9(2)(4)
+	PaymentValue          decimal.Decimal `translator:"part:146..166;precision:2"`        //Valor do título                         147..167   9(021)(2)
+	DiscountValue         decimal.Decimal `translator:"part:167..180;precision:2"`        //Valor do desconto                       168..181   9(012)(2)
+	FinancingValue        decimal.Decimal `translator:"part:181..194;precision:2"`        //Valor liquido                           182..195   9(012)(2)
+	DiscountRate          decimal.Decimal `translator:"part:195..200;precision:4"`        //Taxa de adiantamento                    196..201   9(2)(4)
 	ReferenceNumber       string          `translator:"part:201..229"`                    //Numero de referência                    202..230   X(029)
 	Occurrence            string          `translator:"part:230..239"`                    //Status da Partida/Código de ocorrência  231..240   X(010)
 }
@@ -131,14 +131,14 @@ func (b BillingReturnSegmentA) String() (string, error) {
 }
 
 type BillingReturnBatchTrailer struct {
-	BankCode                string          `translator:"part:0..2"`     //Código do Banco                      001..003   9(003)
-	BatchNumber             int             `translator:"part:3..6"`     //Lote de Serviço                      004..007   9(004
-	RegistryKind            int             `translator:"part:7..7"`     //Tipo de Registro                     008..008   9(001)
-	QuantityRegistries      int             `translator:"part:17..22"`   //Quantidade de Registros do Lote      018..023   9(006)
-	ValueAmount             decimal.Decimal `translator:"part:23..40"`   //Somatória dos Valores                024..041   9(016)V2
-	CurrencyQuantity        decimal.Decimal `translator:"part:41..58"`   //Somatória Quantidade Moeda           042..059   9(013)V5
-	DebitNotificationNumber int             `translator:"part:59..64"`   //Número Aviso de Débito               060..065   9(006)
-	Occurrence              string          `translator:"part:230..239"` //Ocorrências para o Retorno           231..240   X(010)
+	BankCode                string          `translator:"part:0..2"`               //Código do Banco                      001..003   9(003)
+	BatchNumber             int             `translator:"part:3..6"`               //Lote de Serviço                      004..007   9(004
+	RegistryKind            int             `translator:"part:7..7"`               //Tipo de Registro                     008..008   9(001)
+	QuantityRegistries      int             `translator:"part:17..22"`             //Quantidade de Registros do Lote      018..023   9(006)
+	ValueAmount             decimal.Decimal `translator:"part:23..40;precision:2"` //Somatória dos Valores                024..041   9(016)V2
+	CurrencyQuantity        decimal.Decimal `translator:"part:41..58;precision:2"` //Somatória Quantidade Moeda           042..059   9(013)V5
+	DebitNotificationNumber int             `translator:"part:59..64"`             //Número Aviso de Débito               060..065   9(006)
+	Occurrence              string          `translator:"part:230..239"`           //Ocorrências para o Retorno           231..240   X(010)
 }
 
 // TODO criar tag default nas estruturas

--- a/brf240/billing_test.go
+++ b/brf240/billing_test.go
@@ -215,3 +215,43 @@ func TestBillingFileTrailerParse(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expected_file_trailer, parsed)
 }
+
+func TestBillingReturnSegmentAWrite(t *testing.T) {
+	invoiceValue, _ := decimal.NewFromString("22.5")
+	invoiceDiscountValue, _ := decimal.NewFromString("2.5")
+	invoiceFinancingValue, _ := decimal.NewFromString("20.0")
+	invoiceDiscountRate, _ := decimal.NewFromString("0.00644927")
+	expected_segment_a := "BRF0001300001A000G10 TRANSPORTES LTDA                21809202407569161000492   003410000032883        732807000085997-001-001     18092024180920240000000000000000022500000000000025000000000002000000064250051023754842019001        F5        "
+
+	segment_a := brf240.BillingReturnSegmentA{
+		BankCode:              "BRF",
+		BatchNumber:           1,
+		RegistryKind:          3,
+		BatchSequentialNumber: 1,
+		SegmentKind:           "A",
+		ActionKind:            1,
+		ActionInstructionKind: 12,
+		VendorName:            "G10 TRANSPORTES LTDA",
+		DocumentKind:          2,
+		FinancingDate:         time.Date(2024, time.September, 18, 0, 0, 0, 0, time.UTC).Round(0),
+		Document:              "07569161000492",
+		VendorBankCode:        341,
+		VendorAgency:          3288,
+		VendorAgencyCd:        "3",
+		VendorAccount:         "73280",
+		VendorAccountCd:       "7",
+		PaymentNumber:         "000085997-001-001",
+		IssueDate:             time.Date(2024, time.September, 18, 0, 0, 0, 0, time.UTC).Round(0),
+		DueDate:               time.Date(2024, time.September, 18, 0, 0, 0, 0, time.UTC).Round(0),
+		PaymentValue:          invoiceValue,
+		DiscountValue:         invoiceDiscountValue,
+		FinancingValue:        invoiceFinancingValue,
+		DiscountRate:          invoiceDiscountRate,
+		ReferenceNumber:       "250051023754842019001",
+		Occurrence:            "F5",
+	}
+	segment_a_written, err := segment_a.New().String()
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected_segment_a, segment_a_written)
+}

--- a/internal/writer/writer_test.go
+++ b/internal/writer/writer_test.go
@@ -1,6 +1,7 @@
 package writer
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -138,6 +139,33 @@ func Test_structToString(t *testing.T) {
 			wantErr: nil,
 			want:    "        ", // Esperado formato da data zero
 		},
+		{
+			name: "successful struct to string with value with precision",
+			value: struct {
+				Rate decimal.Decimal `translator:"part:0..4;precision:4"`
+			}{
+				Rate: func() decimal.Decimal {
+					dec, _ := decimal.NewFromString("0.00644927")
+					return dec
+				}(),
+			},
+			length:  5,
+			wantErr: nil,
+			want:    "00064",
+		},
+		{
+			name: "error when struct to string with wrong precision",
+			value: struct {
+				Rate decimal.Decimal `translator:"part:0..4;precision:TEST"`
+			}{
+				Rate: func() decimal.Decimal {
+					dec, _ := decimal.NewFromString("0.0064")
+					return dec
+				}(),
+			},
+			length:  5,
+			wantErr: &strconv.NumError{},
+		},
 	}
 
 	for _, tt := range tests {
@@ -148,7 +176,8 @@ func Test_structToString(t *testing.T) {
 				assert.Nil(t, err)
 			}
 			if err != nil {
-				assert.Equal(t, tt.wantErr, err)
+				assert.Error(t, err)
+				assert.IsType(t, tt.wantErr, err)
 			}
 		})
 	}


### PR DESCRIPTION
Before this commit: Only parse was with precision implemented

After this commit:
- Added precision for decimal to writer
- Added tests to writer
- Added tests for `brf240.BillingReturnSegmentA` using `precision:4`